### PR TITLE
Fix merchant's goldface steel boots being leather

### DIFF
--- a/code/modules/cargo/packsrogue/armor.dm
+++ b/code/modules/cargo/packsrogue/armor.dm
@@ -56,8 +56,8 @@
 	name = "Steel Boots"
 	cost = 50
 	contains = list(
-					/obj/item/clothing/shoes/roguetown/boots,
-					/obj/item/clothing/shoes/roguetown/boots,
+					/obj/item/clothing/shoes/roguetown/boots/armor,
+					/obj/item/clothing/shoes/roguetown/boots/armor,
 				)
 
 /datum/supply_pack/rogue/armor/gambeson


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Merchant's goldface gives leather boots when buying "steel boots"

## Why It's Good For The Game

Obviously unintended
